### PR TITLE
Remove token refresh

### DIFF
--- a/controlshift/authenticated.py
+++ b/controlshift/authenticated.py
@@ -73,6 +73,8 @@ class AuthenticatedControlShift:
         return session
 
     def get(self, path, **params):
+        if not self._token:
+            self.refresh_token()
         session = self.create_session()
         try:
             r = session.get('{}{}'.format(self.base_url, path), params=params)

--- a/controlshift/authenticated.py
+++ b/controlshift/authenticated.py
@@ -55,18 +55,33 @@ class AuthenticatedControlShift:
                     'AuthenticatedControlShift requires parameter {}'
                     .format(attr))
 
+        if 'token' in params:
+            self._token = params['token']
         self.client_class = client_class
         self.debug = params.get('debug', False)
+
+    def token_saver(self, token):
+        """
+        Override this method,
+        if you have a place to save auth tokens in your application
+        """
+        if self.debug:
+            print('SAVING TOKEN', token)
+
+    def _token_save_inner(self, token):
+        self._token = token
+        self.token_saver(token)
 
     def refresh_token(self):
         print('CSL Auth: Refreshing token')
         oauth_token_url = '{}/oauth/token'.format(self.base_url)
         client = self.client_class(client_id=self.client_id)
         oauth = OAuth2Session(client=client)
-        self._token = oauth.fetch_token(
+        token = oauth.fetch_token(
             token_url=oauth_token_url,
             client_id=self.client_id,
             client_secret=self.client_secret)
+        self._token_save_inner(token)
 
     def create_session(self):
         print('CSL Auth: Creating session')

--- a/controlshift/authenticated.py
+++ b/controlshift/authenticated.py
@@ -59,6 +59,7 @@ class AuthenticatedControlShift:
         self.debug = params.get('debug', False)
 
     def refresh_token(self):
+        print('CSL Auth: Refreshing token')
         oauth_token_url = '{}/oauth/token'.format(self.base_url)
         client = self.client_class(client_id=self.client_id)
         oauth = OAuth2Session(client=client)
@@ -68,6 +69,7 @@ class AuthenticatedControlShift:
             client_secret=self.client_secret)
 
     def create_session(self):
+        print('CSL Auth: Creating session')
         client = self.client_class(client_id=self.client_id, token=self._token)
         session = OAuth2Session(self.client_id, token=self._token, client=client)
         return session
@@ -77,8 +79,10 @@ class AuthenticatedControlShift:
             self.refresh_token()
         session = self.create_session()
         try:
+            print('CSL Auth: Fetching data')
             r = session.get('{}{}'.format(self.base_url, path), params=params)
         except (TokenExpiredError, ConnectionError) as e:
+            print('CSL Auth: Failed to fetch data using current session')
             print(e)
             self.refresh_token()
             session = self.create_session()


### PR DESCRIPTION
After lots of investigation and conversation with ControlShift support, I believe our intermittent issues connecting from Turtle  to ControlShift have two causes: CSL servers do not support token refresh, and we were persisting each session indefinitely. 

Here are some snippets from my conversation from ControlShift support:
* "I checked the configuration of [doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) (the ruby gem we use for providing OAuth authentication) and it seems like it's not currently set up to generate refresh tokens when issuing the first access token. Could it be possible from your side to, each time an access token expires, request a new token using the initial process instead of requesting using a refresh token?"
* "Is it possible that the code you've written opens a long running http connection over many individual requests, but doesn't handle reopening the connection if it is closed in the middle of a long-running piece of custom application code? It is not necessarily a bug if the other end of a long running http connection is closed by the peer."

Instead of persisting the session indefinitely and refreshing the token automatically, we now create a session for each request to ControlShift, and manually create a new token when the existing one expires or the connection is reset.

One future improvement would be to support a single session for a pre-defined batch of get requests (e.g. when we are running the refresh petition cron job). Another future improvement would be to retry more than once, instead of only handling a single failure. But, I think the approach below will solve most of the errors we currently encounter.

These changes are deployed to the Turtle staging environment. You can search the relevant logs for the string "CSL Auth:" to see the changes in action. I recommend that we deploy these changes to Turtle prod after they are approved but before they are merged, in case we need to make additional changes.